### PR TITLE
docs: 修复 “Mastodon (长毛象）部署流程”页的贡献者显示错误，顶部显示贡献者内容相关信息。

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -40,6 +40,12 @@ export default defineUserConfig({
      lastUpdated: false,
      contributors: {
       mode: 'block',
+      info: [
+        {
+          username: 'bingxin666', // github username
+          alias: ['Bingxin'], // 别名，本地 git 配置中的用户名
+        }
+      ]
     },
     /**
      * 博客

--- a/docs/for-admin/deploy/mastodon.md
+++ b/docs/for-admin/deploy/mastodon.md
@@ -6,6 +6,9 @@ permalink: /for-admin/deploy/mastodon/
 ::: tip
 本页专注于 Mastodon 服务端的部署流程，涉及域名、服务器等资源的内容请至“[必要的数字基建资源](/for-admin/resources/)”查看。
 :::
+::: info 内容相关
+本页由 [@Bingxin](https://github.com/bingxin666) 贡献，内容来自其博客文章（[1](https://blog.byteloid.one/2024/11/01/docker%E9%83%A8%E7%BD%B2mastodon/), [2](https://blog.byteloid.one/2024/12/27/mastodon%E7%AC%AC%E4%BA%8C%E9%83%A8%E5%88%86/)）的优化。
+:::
 
 ## 通过 Docker Compose 部署
 


### PR DESCRIPTION
### PR Checklist
- [x] 如果您提交的修改包含站点配置内容，请经过您本地 `pnpm docs:dev` 的运行并确认没有故障问题。
- [x] 如果涉及新内容，您已经相应地更新了站点的配置项。
